### PR TITLE
Add ".pylintrc" config file for "stbt lint"

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,8 @@
+[MASTER]
+persistent=no
+extension-pkg-whitelist=cv2
+
+[REPORTS]
+msg-template={path}:{line}:{column}: [{msg_id}({symbol}), {obj}] {msg}
+output-format=colorized
+reports=no


### PR DESCRIPTION
Without this, "stbt lint" complains about any use of the "cv2" OpenCV
module:

> $ ./stbt-docker stbt lint --errors-only tests/*.py
> ************* Module utils
> E:126,11: Module 'cv2' has no 'imread' member (no-member)

This is because the "cv2" module is implemented in C, so pylint needs to
*import* it to know what its members are (it can't figure that out using
static analysis, like it does for pure-Python modules).

".pylintrc" is one of the filenames that pylint searches for, so you
don't have to specify it explicitly with "--rcfile".

While we're adding this, we might as well customise pylint's output to
something more sensible, so that it starts each line with
"filename:line:column" like a compiler's error output -- this format
tends to integrate better with editors and IDEs.